### PR TITLE
Fix issue with devbox

### DIFF
--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -121,7 +121,7 @@ in
         echo '#!/bin/sh' >> "${filepath}"
         echo "" >> "${filepath}"
         echo 'export CFG_DIR="${aliuRepo}"' >> "${filepath}"
-        echo 'CUR_SHELL="$(basename "$0" 2>/dev/null || echo "$0" | tr -d "-")"' >> "${filepath}"
+        echo 'CUR_SHELL="$(ps -cp "$$" -o command="" || echo "$0" | tr -d "-")"' >> "${filepath}"
         echo 'IS_INTERACTIVE_SHELL=${isInteractive}' >> "${filepath}"
         echo "" >> "${filepath}"
         echo '. "${aliuRepo}/shell/dispatch"' >> "${filepath}"

--- a/shell/zsh/prompt
+++ b/shell/zsh/prompt
@@ -32,7 +32,7 @@ function parse_git_dirty() {
   local STATUS
   local -a FLAGS
   FLAGS=('--porcelain' '--ignore-submodules=dirty' '--untracked-files=no')
-  if [[ "$(command git config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
+  if [[ "$(command git config --get oh-my-zsh.hide-dirty 2> /dev/null)" != "1" ]]; then
     STATUS=$(command git status ${FLAGS} 2> /dev/null | tail -n1)
   fi
   if [[ -n $STATUS ]]; then


### PR DESCRIPTION
Devbox for whatever reason was calling `.zshrc` directly, resulting in `CUR_SHELL` showing up as `.zshrc` instead of `zsh`, which then breaks dispatch.

This switches from using `basename $0` to `ps -cp "$$" -o command=""` [from this SO post](https://askubuntu.com/questions/590899/how-do-i-check-which-shell-i-am-using)